### PR TITLE
Bugfix average speed and new version of getRuns

### DIFF
--- a/beepbeep/dataservice/static/api.yaml
+++ b/beepbeep/dataservice/static/api.yaml
@@ -383,7 +383,7 @@ paths:
             minimum: 0
         - name: per_page
           in: query
-          description: How many entries you want to retrive in a page. This value is also used to calculate the offset of items in order to display a page
+          description: How many entries you want to retrive in a page default to 10 if the page parameter is set. This value is also used to calculate the offset of items in order to display a page
           schema:
             type: integer
             minimum: 1

--- a/beepbeep/dataservice/static/api.yaml
+++ b/beepbeep/dataservice/static/api.yaml
@@ -375,15 +375,15 @@ paths:
           description: If this parameter is set all the runs returned will have an id greater than from-id
           schema:
             type: integer
-        - name: page-size
+        - name: page
           in: query
-          description: How many entries are present in a page. If this parameter is set the request will return at most page-size items
+          description: The page you want retrive with "per_page" entries
           schema:
             type: integer
-            minimum: 1
-        - name: skip-number
+            minimum: 0
+        - name: per_page
           in: query
-          description: How many entries skip. If this parameter is set the request will skip the first skip-number elements and returns only entries after them
+          description: How many entries you want to retrive in a page. This value is also used to calculate the offset of items in order to display a page
           schema:
             type: integer
             minimum: 1

--- a/beepbeep/dataservice/views/swagger.py
+++ b/beepbeep/dataservice/views/swagger.py
@@ -54,9 +54,8 @@ def get_runs(user_id):
     page = int(request.args.get('page'))
     per_page = int(request.args.get('per_page'))
 
-    print("get Runs lol")
     if per_page is None:
-        per_page = 10 # TODO: write in doc that per_page is 10 by default
+        per_page = 10
 
     if page is None:
         per_page = None
@@ -77,7 +76,6 @@ def get_runs(user_id):
 
     if page is not None and per_page is not None:
         offset = page * per_page
-        limit  = offset + per_page
         runs = runs.offset(offset).limit(per_page)
 
     return jsonify([run.to_json() for run in runs])

--- a/beepbeep/dataservice/views/swagger.py
+++ b/beepbeep/dataservice/views/swagger.py
@@ -42,7 +42,8 @@ def get_average_speed(user_id):
     if q.count() == 0:
         return bad_response(404, 'Error no User with ID ' + user_id)
     u = q.first()
-    return {'average_speed': float('%.2f' % (u.total_speed / u.total_runs))}
+    average_speed = u.total_speed / u.total_runs if u.total_runs > 0 else 0
+    return {'average_speed': float('%.2f' % average_speed)}
 
 
 @api.operation('getRuns')

--- a/beepbeep/dataservice/views/swagger.py
+++ b/beepbeep/dataservice/views/swagger.py
@@ -51,8 +51,16 @@ def get_runs(user_id):
     start_date = request.args.get('start-date')
     finish_date = request.args.get('finish-date')
     max_id = request.args.get('from-id')
-    page_size = request.args.get('page-size')
-    skip_number = request.args.get('skip-number')
+    page = int(request.args.get('page'))
+    per_page = int(request.args.get('per_page'))
+
+    print("get Runs lol")
+    if per_page is None:
+        per_page = 10 # TODO: write in doc that per_page is 10 by default
+
+    if page is None:
+        per_page = None
+
     fun = True
     if not existing_user(user_id):
         return bad_response(404, 'Error no User with ID ' + user_id)
@@ -66,10 +74,12 @@ def get_runs(user_id):
         fun = and_(fun, Run.id > max_id)
     fun = and_(fun, Run.runner_id == user_id)
     runs = db.session.query(Run).filter(fun)
-    if skip_number is not None:
-        runs = runs.offset(skip_number)
-    if page_size is not None:
-        runs = runs.limit(page_size)
+
+    if page is not None and per_page is not None:
+        offset = page * per_page
+        limit  = offset + per_page
+        runs = runs.offset(offset).limit(per_page)
+
     return jsonify([run.to_json() for run in runs])
 
 


### PR DESCRIPTION
## Average Speed
Average Speed now doesn't raise ZeroDivisionError anymore.

## New getRuns parameters
Now getRuns is paged with `/users/{runner_id}/runs?page=0&per_page=10`
That means that you have to pass as parameters:
- page: the page you want to retrive/display
- per_page: number of items you want in a page. This value is also used to calculate the correct offset 